### PR TITLE
Some minor enhancements

### DIFF
--- a/OverwolfPatcher/Classes/Overwolf.cs
+++ b/OverwolfPatcher/Classes/Overwolf.cs
@@ -1,4 +1,5 @@
 ﻿using Bluscream;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -9,12 +10,16 @@ namespace OverwolfPatcher.Classes
     public class Overwolf
     {
         private const string ProcessName = "overwolf";
+        internal const string BaseRegKey = @"SOFTWARE\WOW6432Node\Overwolf";
+        internal const string MainRegKey = @"Software\Overwolf\Overwolf";
+        internal static Uri UrlProtocol => new Uri("overwolfstore://");
+        internal static Uri DownloadUrl => new Uri("https://download.overwolf.com/install/Download?utm_source=web_app_store");
 
         public DirectoryInfo ProgramFolder { get; set; }
         public DirectoryInfo DataFolder { get; set; }
 
         public DirectoryInfo ExtensionsFolder => DataFolder.Combine("Extensions");
-        public List<DirectoryInfo> ProgramVersionFolders => ProgramFolder.GetDirectories(searchPattern: "*.*.*.*").ToList(); // C:\Program Files (x86)\Overwolf\0.258.1.7\
+        public List<DirectoryInfo> ProgramVersionFolders => ProgramFolder.GetDirectories(searchPattern: "*.*.*.*").ToList();
         // public DirectoryInfo WindowsDesktopApp => new DirectoryInfo(@"C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App\8.0.11");
         public List<Process> Processes => Process.GetProcessesByName(ProcessName).ToList();
     }

--- a/OverwolfPatcher/Program.cs
+++ b/OverwolfPatcher/Program.cs
@@ -33,18 +33,17 @@ namespace OverwolfPatcher
                 Console.WriteLine("Overwolf app is running, do you want to close it now? (y/n)");
                 var key = Console.ReadKey();
                 if (key.Key == ConsoleKey.Y) ow.Processes.ForEach(p => { p.Kill(); p.WaitForExit(); });
-                else
-                {
-                    Console.WriteLine("Cannot continue, press any key to exit");
-                    Console.ReadKey();
-                    Utils.Exit(1);
-                }
+                else Utils.ErrorAndExit("Cannot continue with Overwolf running!");
             }
 
-            RegistryKey registryKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\WOW6432Node\Overwolf");
+            RegistryKey registryKey = Registry.LocalMachine.OpenSubKey(Overwolf.BaseRegKey);
+            if (registryKey is null) Utils.ErrorAndExit("Can not find Overwolf registry keys, is Overwolf even installed?", reinstall_overwolf: true);
+
             ow.ProgramFolder = new DirectoryInfo(registryKey.GetValue("InstallFolder").ToString());
 
-            registryKey = Registry.CurrentUser.OpenSubKey(@"Software\Overwolf\Overwolf");
+            registryKey = Registry.CurrentUser.OpenSubKey(Overwolf.MainRegKey);
+            if (registryKey is null) Utils.ErrorAndExit("Can not find Overwolf registry keys, is Overwolf even installed?", reinstall_overwolf: true);
+
             ow.DataFolder = new DirectoryInfo(registryKey.GetValue("UserDataFolder").ToString());
 
             Console.WriteLine();
@@ -58,10 +57,13 @@ namespace OverwolfPatcher
 
             Console.WriteLine();
             Console.WriteLine();
-
+            Console.ForegroundColor = ConsoleColor.Green;
             Console.WriteLine("Complete!");
+            Console.ResetColor();   
 
             Console.ReadKey();
+
+            // Overwolf.UrlProtocol.OpenInDefaultBrowser();
         }
     }
 }

--- a/OverwolfPatcher/Utils/AssemblyInfo.cs
+++ b/OverwolfPatcher/Utils/AssemblyInfo.cs
@@ -2,17 +2,17 @@
 using System.Linq;
 using System.Reflection;
 
-public static class AssemblyInfo
+public static class AssemblyInfo // for some reason this isnt working so i had to hardcode the fallback values
 {
     private static readonly Assembly _assembly = typeof(AssemblyInfo).Assembly;
 
-    public static string Title => GetAttributeOrDefault("Title", "Untitled");
-    public static Version Version => _assembly.GetName().Version;
-    public static string Description => GetAttributeOrDefault("Description", "No description available.");
-    public static string Product => GetAttributeOrDefault("Product", "No product name specified.");
-    public static string Copyright => GetAttributeOrDefault("Copyright", "© No copyright specified.");
-    public static string Trademark => GetAttributeOrDefault("Trademark", "No trademark specified.");
-    public static string Company => GetAttributeOrDefault("Company", "No company specified.");
+    public static string Title => _assembly.GetName().Name ?? GetAttributeOrDefault("Title", "Overwolf Patcher");
+    public static Version Version => _assembly.GetName()?.Version ?? new Version(1,0,0);
+    public static string Description => GetAttributeOrDefault("Description", "Patcher for Overwolf");
+    public static string Product => GetAttributeOrDefault("Product", "OverwolfPatcher");
+    public static string Copyright => GetAttributeOrDefault("Copyright", "© 2025");
+    public static string Trademark => GetAttributeOrDefault("Trademark", "™️");
+    public static string Company => GetAttributeOrDefault("Company", "DecoderCoder, Bluscream");
 
     private static string GetAttributeOrDefault(string attributeName, string defaultValue)
     {

--- a/OverwolfPatcher/Utils/Extensions.cs
+++ b/OverwolfPatcher/Utils/Extensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -375,6 +376,14 @@ public static class Extensions
             match = match.NextMatch();
         }
         return paramaters;
+    }
+    public static void OpenInDefaultBrowser(this Uri uri)
+    {
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = uri.AbsoluteUri,
+            UseShellExecute = true
+        });
     }
     #endregion
     #region Enum

--- a/OverwolfPatcher/Utils/Utils.cs
+++ b/OverwolfPatcher/Utils/Utils.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Security.Principal;
 using System.Threading;
+using OverwolfPatcher.Classes;
 
 namespace Bluscream;
 
@@ -123,5 +124,15 @@ internal static class Utils
             isAdmin = false;
         }
         return isAdmin;
+    }
+    internal static void ErrorAndExit(string message, bool reinstall_overwolf = false)
+    {
+        Console.ForegroundColor = ConsoleColor.Red;
+        Console.WriteLine(message);
+        Console.ResetColor();
+        Console.WriteLine("Press any key to exit...");
+        Console.ReadKey();
+        if (reinstall_overwolf) Overwolf.DownloadUrl.OpenInDefaultBrowser();
+        Exit(1);
     }
 }


### PR DESCRIPTION
Thanks for getting the patcher back up!

- workaround for missing assemblyinfo
- more info when ow isnt installed (gave null error before)
- add some statics to Overwolf class
- open dl page when ow installation corrupt/missing from registry
- add Utils.ErrorAndExit(string message, bool reinstall_overwolf = false) helper method

Everything added was tested and confirmed working on OW 0.270.0.11 on Win 11